### PR TITLE
chore: add Gemfile.lock and .ruby-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ doc/doc-*
 doc/po/rubysdl2.pot
 extconf-options.txt
 .gem_rbs_collection/
+Gemfile.lock
+.ruby-version


### PR DESCRIPTION
## Summary

Add `Gemfile.lock` and `.ruby-version` to `.gitignore`.

These files are auto-generated by bundler and rbenv respectively, and should not be tracked in a gem library repository. Previously they were only ignored by the user's personal global gitignore.

## Related

- smalruby/smalruby3-editor#409
